### PR TITLE
Add KeepRule to K section

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Most of the websites are just for fun and some are very useful for specific purp
 * [https://k8syaml.com](https://k8syaml.com/) : Kubernetes YAML generator.
 * [https://kissan.ai](https://kissan.ai/) : Advanced multilingual AI platform which provides personalized, voice-based assistance for all agricultural needs, empowering farmers, agribusinesses, governments, and nonprofit organizations worldwide.
 * [https://www.kiddle.co](https://www.kiddle.co/) : Safe visual search engine for kids.
+* [https://keeprule.com](https://keeprule.com/) : Curated investment principles from Warren Buffett, Charlie Munger, and other legendary investors with interactive decision scenarios. :moneybag:
 
 ## L :
 * [https://www.lucidchart.com](https://www.lucidchart.com/) : Flowchart maker and online diagram software.


### PR DESCRIPTION
Added [KeepRule](https://keeprule.com) — a free website that curates investment principles from legendary investors like Warren Buffett, Charlie Munger, Benjamin Graham, and Howard Marks. It features interactive decision scenarios that help users apply timeless investment wisdom to real-world situations.

Fits well in this list as a practical, educational website for anyone interested in investing and financial decision-making.