### PR TITLE
Add WhatIsTheDay — weekday & calendar converter for any date

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Most of the websites are just for fun and some are very useful for specific purp
 
 ## W :
 * [http://weavesilk.com](http://weavesilk.com/) : Totally mind blowing. Create dreamy works of art with your mouse. Have fun! :curly_loop:
+* [https://www.whatistheday.com](https://www.whatistheday.com/) : Enter any date — past, future, or even BC — and instantly see its day of the week, holidays, famous birthdays, historical events, and conversions across 10+ calendar systems (Hebrew, Islamic, Chinese, Maya and more). :calendar:
 * [https://www.woorank.com](https://www.woorank.com/) : Free Website Review Tool & SEO Checker. Enter your URL for a free instant website review and SEO audit for any site.
 * [http://weirdorconfusing.com](http://weirdorconfusing.com/) : Go to this site to buy weird and confusing thing. Things can go really weird 😉
 * [http://www.windows93.net](http://www.windows93.net/) : Use old Windows on your browser and live your past again.


### PR DESCRIPTION
Adding [WhatIsTheDay](https://www.whatistheday.com/) to the W section.

It answers "what day of the week is/was any date?" for any date in history — including BC dates (with correct Julian/Gregorian handling before 1582). Beyond the weekday it shows holidays, famous birthdays, historical events, and converts the date across 10+ calendar systems (Hebrew, Islamic, Persian, Chinese, Maya, Egyptian, Babylonian).

Free, no registration, no ads-wall — all calculations run client-side in the browser.