### PR TITLE
Add Toolio under T

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ Most of the websites are just for fun and some are very useful for specific purp
 * [https://www.timetodecimalcalculator.com/](https://www.timetodecimalcalculator.com/) : Free time to decimal calculator
 * [https://tinytools-smoky.vercel.app](https://tinytools-smoky.vercel.app/) : Free single-purpose web utilities, all browser-based, no signup. Includes favicon generator, OG image generator, color palette generator, SEO meta tag generator, AI background remover (runs locally), domain name generator, AI cost calculator and more. Open source.
 * [https://tinyfingers.net](https://tinyfingers.net) : TinyFingers is the official fullscreen website where babies and toddlers can safely smash the keyboards and see playful animations.
+* [https://toolio.pongvn.com](https://toolio.pongvn.com/) : 195 browser tools in one place — PDF, image, converters, calculators and developer utilities. Most of them run client-side, so your files never leave the browser. No signup. :free:
 
 
 ## U :


### PR DESCRIPTION
Adds [Toolio](https://toolio.pongvn.com) to the **T** section.

Toolio puts 195 free browser tools in one place — PDF, image, converters, calculators and developer utilities. Most of them run client-side, so files never leave the browser. No signup, no install.

- Placed at the end of `## T :`, following the existing `* [url](url) : Description.` format (same shape as the TinyTools entry just above).
- Full disclosure: I'm the maker. Happy to reword the description or drop it if it isn't a fit for the list.

Thanks for the collection!