### PR TITLE
Add Nutilz Mortgage Affordability Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Most of the websites are just for fun and some are very useful for specific purp
 * [https://nickmakes.website](https://nickmakes.website/) : NYC-based creative web developer named Nick Ellsworth. Here's some stuff that he created which you may find fun or weird.
 * [https://nohello.net](https://nohello.net/) : You SHOULD definitely go through this website before you text anyone if you're the person who just says hi/hello to initiate a conversation over chatting.
 * [https://dalton-nrs.manchester.ac.uk](https://dalton-nrs.manchester.ac.uk/) : Take a tour of Virtual nuclear reactor. 
+* [https://nutilz.com/mortgage-affordability-calculator](https://nutilz.com/mortgage-affordability-calculator) : Free mortgage affordability calculator — estimates how much house you can afford based on income, debts, down payment, and interest rate. No signup required. :free: :house:
 
 ## O :
 * [http://oldcomputers.net](http://oldcomputers.net/) : The museum of old, rare, vintage, antique computers. View all 150 old computers all at the same time to appreciate how diverse and interesting they are. :computer:


### PR DESCRIPTION
Adds a free, no-signup mortgage affordability calculator (https://nutilz.com/mortgage-affordability-calculator) to the N section, alongside the other free calculator/tool entries already in the list (Acalcia, Concrete Calculator Hub, etc.). Helps users estimate how much house they can afford from income, debts, down payment, and rate.