### PR TITLE
Add Nutilz Time Calculator to N section

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Most of the websites are just for fun and some are very useful for specific purp
 * [https://nickmakes.website](https://nickmakes.website/) : NYC-based creative web developer named Nick Ellsworth. Here's some stuff that he created which you may find fun or weird.
 * [https://nohello.net](https://nohello.net/) : You SHOULD definitely go through this website before you text anyone if you're the person who just says hi/hello to initiate a conversation over chatting.
 * [https://dalton-nrs.manchester.ac.uk](https://dalton-nrs.manchester.ac.uk/) : Take a tour of Virtual nuclear reactor. 
+* [https://nutilz.com/time-calculator](https://nutilz.com/time-calculator) : Free browser-based time calculator — find the hours and minutes between two times, add or subtract a duration, and convert to decimal hours for payroll and timesheets. No upload or signup required. :free:
 
 ## O :
 * [http://oldcomputers.net](http://oldcomputers.net/) : The museum of old, rare, vintage, antique computers. View all 150 old computers all at the same time to appreciate how diverse and interesting they are. :computer:


### PR DESCRIPTION
Adds nutilz.com/time-calculator — a free, browser-based tool for finding the duration between two times, adding/subtracting a time duration, and converting to decimal hours for payroll/timesheets. No signup, runs client-side. Matches the format of existing entries in the N section.