### PR TITLE
Add All Tools Verse to the A section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Most of the websites are just for fun and some are very useful for specific purp
 * [https://amazingnewsletters.com](https://amazingnewsletters.com) : Find the best newsletters to subscribe to! Amazing Newsletters curates top content for your inbox. Dive in and discover.
 * [https://dinosaurpictures.org/ancient-earth#170](https://dinosaurpictures.org/ancient-earth#170) : Ancient Earth Globe 🌍 How did Earth look like __ years ago?
 * [https://alltools.dev](https://alltools.dev/) : 500+ free online calculators, converters and generators that run entirely in your browser. No signup needed. :free:
+* [https://alltoolsverse.com](https://alltoolsverse.com/) : 1,000+ free browser tools for development, files, images, text, data conversion, calculations and everyday tasks. No signup required. :free:
 
 ## B :
 * [https://bundle.js.org](https://bundle.js.org) : A quick and easy way to bundle, minify, and compress (gzip and brotli) your ts, js, jsx and npm projects all online, while returning the final bundle file size.


### PR DESCRIPTION
Adds **All Tools Verse** (https://alltoolsverse.com/) to the **A** section beside the existing alltools.dev entry.

All Tools Verse is a collection of 1,000+ free browser tools for development, files, images, text, data conversion, calculations, and everyday tasks. No signup is required.

Why it fits:

- the list already includes comparable browser tool collections such as TinyTools, Discover Web Tools, and alltools.dev
- the entry follows the existing URL, description, and `:free:` format
- only one README line was added

Checks:

- verified the site loads
- confirmed there is no existing All Tools Verse entry
- ran `git diff --check`

Disclosure: I am the maker.