### PR TITLE
Add AISOTools to A section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Most of the websites are just for fun and some are very useful for specific purp
 * [https://dinosaurpictures.org/ancient-earth#170](https://dinosaurpictures.org/ancient-earth#170) : Ancient Earth Globe 🌍 How did Earth look like __ years ago?
 * [https://alltools.dev](https://alltools.dev/) : 500+ free online calculators, converters and generators that run entirely in your browser. No signup needed. :free:
 * [https://alltoolsverse.com](https://alltoolsverse.com/) : 1,000+ free browser tools for development, files, images, text, data conversion, calculations and everyday tasks. No signup required. :free:
+* [https://aisotools.com](https://aisotools.com/) : A directory of 1,200+ AI tools across 21 categories with search, side-by-side comparison and an AI-search visibility monitor. Listing a tool is free. :free:
 
 ## B :
 * [https://bundle.js.org](https://bundle.js.org) : A quick and easy way to bundle, minify, and compress (gzip and brotli) your ts, js, jsx and npm projects all online, while returning the final bundle file size.


### PR DESCRIPTION
Adds one line to the **A** section, appended after `alltoolsverse.com`.

```
* [https://aisotools.com](https://aisotools.com/) : A directory of 1,200+ AI tools across 21 categories with search, side-by-side comparison and an AI-search visibility monitor. Listing a tool is free. :free:
```

**Disclosure:** I run AISOTools, so this is a self-submission. You merged my `ReplacedByAI` entry in #86 (still live in the R section) — flagging that so you know it's the same contributor and can weigh it accordingly.

Notes:
- Matches the file's format exactly: `* [url](url/) : description.` with a trailing `:free:` shortcode, which is accurate — listing a tool costs nothing and includes a dofollow link. There is an optional paid tier, but it only skips the review queue, so I did not describe the site as paid.
- The A section already carries `aitools.fyi`, a directory in the same category, so this sits alongside a comparable entry rather than opening a new one.
- Tool and category counts read from production today; written as "1,200+" rather than the exact figure so the line does not go stale in your file.
- `https://aisotools.com` returns 200. No UTM or referral parameters on the link.
- Diff is a single added line.