### PR TITLE
Add ServerBuddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Most of the websites are just for fun and some are very useful for specific purp
 * [https://share-text.org/](https://share-text.org/): #1 Share Text Online With Link and QR Code, Create, Paste, Edit, and share text online live quickly with secure links and QR codes. Free, no Login and anonymous sharing.
 * [https://sreuniversity.in](https://sreuniversity.in) : This website provides a comprehensive guide to Site Reliability Engineering (SRE), covering its definition, core responsibilities, historical context, a detailed skill roadmap, and recommended learning resources for aspiring engineers.
 * [https://soccon.in](https://soccon.in) : From visitor management to finance tracking — SocietyConnect is the all-in-one platform for modern housing communities. No more spreadsheets, no more chaos.
+* [https://serverbuddy.net](https://serverbuddy.net/) : Search Minecraft servers and view live status, player-count history, uptime, MOTD, and version changes. :free:
 
 ## T :
 * [http://typatone.com](http://typatone.com/) : Type some random stuff and enjoy the music.


### PR DESCRIPTION
Adds ServerBuddy to the S section as a free Minecraft server discovery and telemetry website.

The link is live over HTTPS, and the entry describes the public status, player-history, uptime, MOTD, and version-history features.

Affiliation disclosure: this submission comes from ServerBuddy.