### PR TITLE
Add Calculator Campus

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Most of the websites are just for fun and some are very useful for specific purp
 * [https://concreteestimatorhub.com/](https://concreteestimatorhub.com/) : Free concrete calculators and reference guides for volume, bag counts, slabs, footings, post holes, shed bases, ready-mix comparisons, and material cost planning. :free:
 * [https://www.car-pdi.app](https://www.car-pdi.app) : A digital and printable Pre-Delivery Inspection (PDI) checklist to help car buyers thoroughly inspect their new vehicle before accepting delivery, ensuring they verify critical details like VIN numbers and document any defects.
 * [https://crzy.site](https://crzy.site/) : A growing collection of absolutely pointless single-page websites. Each one dumber than the last.
+* [https://www.calculatorcampus.com/](https://www.calculatorcampus.com/) : Free online calculators with clear formulas, worked examples, and named sources. :free:
 
 ## D : 
 * [http://downforeveryoneorjustme.com](http://downforeveryoneorjustme.com/) : Check if a website is down for everyone or just you.


### PR DESCRIPTION
Adds Calculator Campus to the C section: free online calculators with clear formulas, worked examples, and named sources.

The site is not already listed, and this is a one-line addition in the repository’s existing format.