### PR TITLE
Add Refentra image tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Most of the websites are just for fun and some are very useful for specific purp
 * [https://quenq.com](https://quenq.com) : Project Quenq is an interactive museum of internet culture. Our library features fully functional emulators, preserved games, and rare digital artifacts, all restored to run perfectly in your browser.
 
 ## R : 
-* [https://refentra.com/tools/images-to-pdf/](https://refentra.com/tools/images-to-pdf/) : Combine 1–25 JPEG, PNG, or static WebP images into one ordered PDF with A4, Letter, or image-fitted pages. Free, no signup, and image processing stays in the browser. :free:
+* [https://refentra.com](https://refentra.com) : Free image tools for resizing, compression, format conversion, photo metadata editing and removal, and combining images into PDF. Image processing stays in your browser; no signup required. :free:
 * [https://relatedrepos.com](https://relatedrepos.com/) : Discover related open source projects. Find alternatives and other similar repositories. Updated daily.
 * [http://rainymood.com](http://rainymood.com/) : Listen to rain and thunderstorms online. :umbrella:
 * [https://roadtrippers.com](https://roadtrippers.com/) : Plan your next road trip.

--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Most of the websites are just for fun and some are very useful for specific purp
 * [https://quenq.com](https://quenq.com) : Project Quenq is an interactive museum of internet culture. Our library features fully functional emulators, preserved games, and rare digital artifacts, all restored to run perfectly in your browser.
 
 ## R : 
+* [https://refentra.com/tools/images-to-pdf/](https://refentra.com/tools/images-to-pdf/) : Combine 1–25 JPEG, PNG, or static WebP images into one ordered PDF with A4, Letter, or image-fitted pages. Free, no signup, and image processing stays in the browser. :free:
 * [https://relatedrepos.com](https://relatedrepos.com/) : Discover related open source projects. Find alternatives and other similar repositories. Updated daily.
 * [http://rainymood.com](http://rainymood.com/) : Listen to rain and thunderstorms online. :umbrella:
 * [https://roadtrippers.com](https://roadtrippers.com/) : Plan your next road trip.


### PR DESCRIPTION
Adds the Refentra website under R. It offers free tools for resizing, target-size compression, image format conversion, photo metadata editing/removal, and combining images into PDF. Source images are processed locally in the browser without signup.

I maintain Refentra. Its application source is private, and its development and this contribution are AI-assisted. I reviewed the wording and public homepage for accuracy.

Validation: the homepage returns HTTP 200; the final diff adds one website entry. The published README was reread and verified against the reviewed text.